### PR TITLE
Add metadata to action to allow extending the library

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -4,7 +4,7 @@ locals_without_parens = [
   allow: 1,
   deny: 1,
   desc: 1,
-  metadata: 1,
+  metadata: 2,
   pre_hooks: 1
 ]
 

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -2,8 +2,9 @@
 
 locals_without_parens = [
   allow: 1,
-  desc: 1,
   deny: 1,
+  desc: 1,
+  metadata: 1,
   pre_hooks: 1
 ]
 

--- a/README.md
+++ b/README.md
@@ -257,8 +257,9 @@ defmodule GraphqlPolicy do
   use LetMe.Policy
 
   object :user do
-    action :disable, gql_exclude: true do
+    action :disable do
       allow role: :admin
+      metadata gql_exclude: true
     end
   end
 end

--- a/README.md
+++ b/README.md
@@ -201,7 +201,8 @@ iex> MyApp.Policy.list_rules()
     description: nil,
     name: :article_create,
     object: :article,
-    pre_hooks: []
+    pre_hooks: [],
+    metadata: []
   },
   # ...
 ]
@@ -239,6 +240,46 @@ iex> MyApp.Policy.list_rules(allow: {:role, :writer})
     # ...
   }
 ]
+```
+
+Metadata can be defined on an `action` for use in extending LetMe's
+functionality that are out of scope for the library itself.
+
+For example, you may want to expose some of your actions through your Absinthe
+GraphQL schema. Perhaps you wanted to exclude only certain actions. Using the
+`action`'s metadata, it becomes easier to do so.
+
+With `metadata`, there should be no limit to how the library can be extended
+in your own application.
+
+```elixir
+defmodule GraphqlPolicy do
+  use LetMe.Policy
+
+  object :user do
+    action :disable, gql_exclude: true do
+      allow role: :admin
+    end
+  end
+end
+```
+
+```elixir
+iex> MyApp.Policy.get_rule(:user_disable)
+%LetMe.Rule{
+  action: :disable,
+  allow: [
+    [role: :admin]
+  ],
+  deny: [],
+  description: nil,
+  name: :user_disable,
+  object: :user,
+  pre_hooks: [],
+  metadata: [
+    gql_exclude: true
+  ]
+}
 ```
 
 ## Scoped queries

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ You can also define metadata on an `action`, which can be useful to extend
 the functionality of the library.
 
 For example, you may want to expose some of your actions through your Absinthe
-GraphQL schema, but exclude certain actions from the schema. You could solve
+GraphQL schema, but exclude certain actions from it. You could solve
 this by adding a `:gql_exclude` key to the metadata.
 
 ```elixir

--- a/README.md
+++ b/README.md
@@ -242,8 +242,8 @@ iex> MyApp.Policy.list_rules(allow: {:role, :writer})
 ]
 ```
 
-Metadata can be defined on an `action` for use in extending LetMe's
-functionality that are out of scope for the library itself.
+You can also define metadata on an `action`, which can be useful to extend
+the functionality of the library.
 
 For example, you may want to expose some of your actions through your Absinthe
 GraphQL schema. Perhaps you wanted to exclude only certain actions. Using the

--- a/README.md
+++ b/README.md
@@ -246,11 +246,8 @@ You can also define metadata on an `action`, which can be useful to extend
 the functionality of the library.
 
 For example, you may want to expose some of your actions through your Absinthe
-GraphQL schema. Perhaps you wanted to exclude only certain actions. Using the
-`action`'s metadata, it becomes easier to do so.
-
-With `metadata`, there should be no limit to how the library can be extended
-in your own application.
+GraphQL schema, but exclude certain actions from the schema. You could solve
+this by adding a `:gql_exclude` key to the metadata.
 
 ```elixir
 defmodule GraphqlPolicy do

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ defmodule GraphqlPolicy do
   object :user do
     action :disable do
       allow role: :admin
-      metadata gql_exclude: true
+      metadata :gql_exclude, true
     end
   end
 end

--- a/cheatsheets/rules.cheatmd
+++ b/cheatsheets/rules.cheatmd
@@ -271,3 +271,46 @@ object :article do
   end
 end
 ```
+
+### Metadata
+
+```elixir
+object :article do
+  action :create do
+    allow role: :admin
+    allow role: :editor
+    allow role: :writer
+    
+    metadata deprecated: "Use :article_post instead"
+  end
+end
+```
+
+### Metadata multiple in one
+
+```elixir
+object :article do
+  action :create do
+    allow role: :admin
+    allow role: :editor
+    allow role: :writer
+    
+    metadata deprecated: "Use :article_post instead", gql_exclude: true
+  end
+end
+```
+
+### Metadata multiple in many
+
+```elixir
+object :article do
+  action :create do
+    allow role: :admin
+    allow role: :editor
+    allow role: :writer
+    
+    metadata deprecated: "Use :article_post instead"
+    metadata gql_exclude: true
+  end
+end
+```

--- a/cheatsheets/rules.cheatmd
+++ b/cheatsheets/rules.cheatmd
@@ -282,20 +282,6 @@ object :article do
     allow role: :writer
     
     metadata :gql_exclude, true
-  end
-end
-```
-
-### Metadata multiple
-
-```elixir
-object :article do
-  action :create do
-    allow role: :admin
-    allow role: :editor
-    allow role: :writer
-    
-    metadata :gql_exclude, true
     metadata :doc_ja, "指定されたユーザーに対して、指定された機能を無効にします。" 
   end
 end

--- a/cheatsheets/rules.cheatmd
+++ b/cheatsheets/rules.cheatmd
@@ -281,12 +281,12 @@ object :article do
     allow role: :editor
     allow role: :writer
     
-    metadata deprecated: "Use :article_post instead"
+    metadata :gql_exclude, true
   end
 end
 ```
 
-### Metadata multiple in one
+### Metadata multiple
 
 ```elixir
 object :article do
@@ -295,22 +295,8 @@ object :article do
     allow role: :editor
     allow role: :writer
     
-    metadata deprecated: "Use :article_post instead", gql_exclude: true
-  end
-end
-```
-
-### Metadata multiple in many
-
-```elixir
-object :article do
-  action :create do
-    allow role: :admin
-    allow role: :editor
-    allow role: :writer
-    
-    metadata deprecated: "Use :article_post instead"
-    metadata gql_exclude: true
+    metadata :gql_exclude, true
+    metadata :doc_ja, "指定されたユーザーに対して、指定された機能を無効にします。" 
   end
 end
 ```

--- a/cheatsheets/rules.cheatmd
+++ b/cheatsheets/rules.cheatmd
@@ -272,7 +272,8 @@ object :article do
 end
 ```
 
-### Metadata
+## Metadata
+{: .col-2}
 
 ```elixir
 object :article do
@@ -282,7 +283,7 @@ object :article do
     allow role: :writer
     
     metadata :gql_exclude, true
-    metadata :doc_ja, "指定されたユーザーに対して、指定された機能を無効にします。" 
+    metadata :desc_ja, "ユーザーが新しい記事を作成できるようにする"
   end
 end
 ```

--- a/lib/let_me/policy.ex
+++ b/lib/let_me/policy.ex
@@ -811,10 +811,8 @@ defmodule LetMe.Policy do
   @doc """
   Assigns metadata to the action in the form of a key value pair.
 
-  Keys should always be atoms.
-
   The metadata can be accessed from the `LetMe.Rule` struct. You can use it
-  to extend the functionality of your policy.
+  to extend the functionality of the library.
 
   ## Example
 
@@ -822,9 +820,54 @@ defmodule LetMe.Policy do
         action :create do
           allow role: :writer
 
-          metadata :doc_ja, "指定されたユーザーに対して、指定された機能を無効にします。"
+          desc "Allows a user to create a new article."
+          metadata :desc_ja, "ユーザーが新しい記事を作成できるようにする"
         end
       end
+
+  The `LetMe.Rule` struct returned by the introspection functions would look
+  like this:
+
+      %LetMe.Rule{
+        action: :create,
+        allow: [[role: :writer]],
+        deny: [],
+        description: "Allows a user to create a new article.",
+        name: :article_create,
+        object: :article,
+        pre_hooks: [],
+        metadata: [
+          desc_ja: "ユーザーが新しい記事を作成できるようにする"
+        ]
+      }
+
+  It is also possible to use the `metadata` macro multiple times.
+
+      object :article do
+        action :create do
+          allow role: :writer
+
+          desc "Allows a user to create a new article."
+          metadata :desc_ja, "ユーザーが新しい記事を作成できるようにする"
+          metadata :desc_es, "Permite al usuario crear un nuevo artículo."
+        end
+      end
+
+  This would result in:
+
+      %LetMe.Rule{
+        action: :create,
+        allow: [[role: :writer]],
+        deny: [],
+        description: "Allows a user to create a new article.",
+        name: :article_create,
+        object: :article,
+        pre_hooks: [],
+        metadata: [
+          desc_ja: "ユーザーが新しい記事を作成できるようにする",
+          desc_es: "Permite al usuario crear un nuevo artículo."
+        ]
+      }
   """
   @spec metadata(atom(), term()) :: Macro.t()
   defmacro metadata(key, value) do

--- a/lib/let_me/policy.ex
+++ b/lib/let_me/policy.ex
@@ -828,6 +828,14 @@ defmodule LetMe.Policy do
   """
   @spec metadata(atom(), term()) :: Macro.t()
   defmacro metadata(key, value) do
+    unless is_atom(key) do
+      raise """
+      Invalid metadata key.
+
+      Expected an atom, got: #{inspect(key)}
+      """
+    end
+
     quote do
       current_meta = get_acc_attribute(__MODULE__, :metadata)
       new_meta = {unquote(key), unquote(value)}

--- a/lib/let_me/policy.ex
+++ b/lib/let_me/policy.ex
@@ -810,6 +810,7 @@ defmodule LetMe.Policy do
 
   @doc """
   Assigns metadata to the action in the form of a key value pair.
+
   Keys should always be atoms.
 
   The metadata can be accessed from the `LetMe.Rule` struct. You can use it

--- a/lib/let_me/policy.ex
+++ b/lib/let_me/policy.ex
@@ -809,7 +809,8 @@ defmodule LetMe.Policy do
   end
 
   @doc """
-  Assigns metadata to the action in the form of a keyword list
+  Assigns metadata to the action in the form of a key value pair.
+  Keys should always be atoms.
 
   The metadata can be accessed from the `LetMe.Rule` struct. You can use it
   to extend the functionality of your policy.
@@ -820,20 +821,16 @@ defmodule LetMe.Policy do
         action :create do
           allow role: :writer
 
-          metadata deprecated: "Cannot create articles with this policy."
+          metadata :doc_ja, "指定されたユーザーに対して、指定された機能を無効にします。"
         end
       end
   """
-  @spec metadata(Keyword.t()) :: Macro.t()
-  defmacro metadata(metadata) do
+  @spec metadata(atom(), term()) :: Macro.t()
+  defmacro metadata(key, value) do
     quote do
-      current = get_acc_attribute(__MODULE__, :metadata)
-
-      Module.put_attribute(
-        __MODULE__,
-        :metadata,
-        current ++ unquote(metadata)
-      )
+      current_meta = get_acc_attribute(__MODULE__, :metadata)
+      new_meta = {unquote(key), unquote(value)}
+      Module.put_attribute(__MODULE__, :metadata, [new_meta | current_meta])
     end
   end
 

--- a/lib/let_me/policy.ex
+++ b/lib/let_me/policy.ex
@@ -453,6 +453,7 @@ defmodule LetMe.Policy do
       Module.register_attribute(__MODULE__, :allow_checks, accumulate: true)
       Module.register_attribute(__MODULE__, :deny_checks, accumulate: true)
       Module.register_attribute(__MODULE__, :pre_hooks, accumulate: true)
+      Module.register_attribute(__MODULE__, :metadata, accumulate: true)
 
       @behaviour LetMe.Policy
 
@@ -597,8 +598,8 @@ defmodule LetMe.Policy do
         end
       end
   """
-  @spec action(atom | [atom], Macro.t()) :: Macro.t()
-  defmacro action(names, do: block) do
+  @spec action(atom | [atom], Keyword.t(), Macro.t()) :: Macro.t()
+  defmacro action(names, metadata \\ [], do: block) do
     names = List.wrap(names)
 
     quote do
@@ -607,6 +608,7 @@ defmodule LetMe.Policy do
       Module.delete_attribute(__MODULE__, :description)
       Module.delete_attribute(__MODULE__, :deny_checks)
       Module.delete_attribute(__MODULE__, :pre_hooks)
+      Module.delete_attribute(__MODULE__, :metadata)
 
       # compile inner block
       unquote(block)
@@ -618,7 +620,8 @@ defmodule LetMe.Policy do
           description: Module.get_attribute(__MODULE__, :description),
           deny: get_acc_attribute(__MODULE__, :deny_checks),
           pre_hooks:
-            __MODULE__ |> get_acc_attribute(:pre_hooks) |> List.flatten()
+            __MODULE__ |> get_acc_attribute(:pre_hooks) |> List.flatten(),
+          metadata: unquote(metadata)
         })
       end
     end
@@ -864,7 +867,8 @@ defmodule LetMe.Policy do
           description: action.description,
           name: :"#{unquote(name)}_#{action.name}",
           object: unquote(name),
-          pre_hooks: action.pre_hooks
+          pre_hooks: action.pre_hooks,
+          metadata: action.metadata
         })
       end
     end

--- a/lib/let_me/rule.ex
+++ b/lib/let_me/rule.ex
@@ -20,6 +20,7 @@ defmodule LetMe.Rule do
   - `object` - The object that the action is performed on, e.g. `:article`.
   - `pre_hooks` - Functions to run in order to hydrate the subject and/or object
     before running the allow and deny checks.
+  - `metadata` - A list of relevant metadata useful for extending functionality.
 
   The list entries in the outer list of the `allow` and `deny` fields are
   combined with a logical `OR`. If one of the entries is a list of checks, those
@@ -39,7 +40,8 @@ defmodule LetMe.Rule do
           description: String.t() | nil,
           name: atom,
           object: atom,
-          pre_hooks: [hook]
+          pre_hooks: [hook],
+          metadata: Keyword.t()
         }
 
   @typedoc """
@@ -81,5 +83,6 @@ defmodule LetMe.Rule do
             description: nil,
             name: nil,
             object: nil,
-            pre_hooks: []
+            pre_hooks: [],
+            metadata: []
 end

--- a/test/let_me/policy_test.exs
+++ b/test/let_me/policy_test.exs
@@ -66,7 +66,8 @@ defmodule LetMe.PolicyTest do
         allow []
       end
 
-      action :with_metadata, metadata_key_one: :useless_check do
+      action :with_metadata do
+        metadata metadata_key_one: :useless_check
       end
     end
 
@@ -150,7 +151,9 @@ defmodule LetMe.PolicyTest do
                  object: :user,
                  pre_hooks: [],
                  metadata: [
-                   deprecated: "Hard deletion is deprecated"
+                   gql_exclude: true,
+                   deprecated: "Hard deletion is deprecated",
+                   replacement: :remove
                  ]
                },
                %Rule{
@@ -160,6 +163,15 @@ defmodule LetMe.PolicyTest do
                  name: :user_list,
                  object: :user,
                  pre_hooks: []
+               },
+               %Rule{
+                 action: :remove,
+                 allow: [[role: :super_admin]],
+                 deny: [],
+                 name: :user_remove,
+                 object: :user,
+                 pre_hooks: [],
+                 metadata: []
                },
                %Rule{
                  action: :view,

--- a/test/let_me/policy_test.exs
+++ b/test/let_me/policy_test.exs
@@ -67,7 +67,7 @@ defmodule LetMe.PolicyTest do
       end
 
       action :with_metadata do
-        metadata metadata_key_one: :useless_check
+        metadata :doc_ja, "指定されたユーザーに対して、指定された機能を無効にします。"
       end
     end
 
@@ -152,8 +152,7 @@ defmodule LetMe.PolicyTest do
                  pre_hooks: [],
                  metadata: [
                    gql_exclude: true,
-                   deprecated: "Hard deletion is deprecated",
-                   replacement: :remove
+                   doc_ja: "指定されたユーザーに対して、指定された機能を無効にします。"
                  ]
                },
                %Rule{

--- a/test/let_me/policy_test.exs
+++ b/test/let_me/policy_test.exs
@@ -65,6 +65,9 @@ defmodule LetMe.PolicyTest do
       action :empty_list_check do
         allow []
       end
+
+      action :with_metadata, metadata_key_one: :useless_check do
+      end
     end
 
     object :complex, MyApp.Blog.Article do
@@ -145,7 +148,10 @@ defmodule LetMe.PolicyTest do
                  deny: [:same_user],
                  name: :user_delete,
                  object: :user,
-                 pre_hooks: []
+                 pre_hooks: [],
+                 metadata: [
+                   deprecated: "Hard deletion is deprecated"
+                 ]
                },
                %Rule{
                  action: :list,

--- a/test/let_me/policy_test.exs
+++ b/test/let_me/policy_test.exs
@@ -67,7 +67,7 @@ defmodule LetMe.PolicyTest do
       end
 
       action :with_metadata do
-        metadata :doc_ja, "指定されたユーザーに対して、指定された機能を無効にします。"
+        metadata :desc_ja, "指定されたユーザーに対して、指定された機能を無効にします。"
       end
     end
 
@@ -152,7 +152,7 @@ defmodule LetMe.PolicyTest do
                  pre_hooks: [],
                  metadata: [
                    gql_exclude: true,
-                   doc_ja: "指定されたユーザーに対して、指定された機能を無効にします。"
+                   desc_ja: "ユーザーアカウントを削除できるようにする"
                  ]
                },
                %Rule{

--- a/test/support/policy.ex
+++ b/test/support/policy.ex
@@ -25,7 +25,7 @@ defmodule MyApp.Policy do
       allow role: :admin
       deny :same_user
       metadata :gql_exclude, true
-      metadata :doc_ja, "指定されたユーザーに対して、指定された機能を無効にします。"
+      metadata :desc_ja, "ユーザーアカウントを削除できるようにする"
     end
 
     action :remove do

--- a/test/support/policy.ex
+++ b/test/support/policy.ex
@@ -21,7 +21,7 @@ defmodule MyApp.Policy do
   end
 
   object :user do
-    action :delete do
+    action :delete, deprecated: "Hard deletion is deprecated" do
       allow role: :admin
       deny :same_user
     end

--- a/test/support/policy.ex
+++ b/test/support/policy.ex
@@ -21,9 +21,15 @@ defmodule MyApp.Policy do
   end
 
   object :user do
-    action :delete, deprecated: "Hard deletion is deprecated" do
+    action :delete do
       allow role: :admin
       deny :same_user
+      metadata deprecated: "Hard deletion is deprecated", replacement: :remove
+      metadata gql_exclude: true
+    end
+
+    action :remove do
+      allow role: :super_admin
     end
 
     action :list do

--- a/test/support/policy.ex
+++ b/test/support/policy.ex
@@ -24,8 +24,8 @@ defmodule MyApp.Policy do
     action :delete do
       allow role: :admin
       deny :same_user
-      metadata deprecated: "Hard deletion is deprecated", replacement: :remove
-      metadata gql_exclude: true
+      metadata :gql_exclude, true
+      metadata :doc_ja, "指定されたユーザーに対して、指定された機能を無効にします。"
     end
 
     action :remove do


### PR DESCRIPTION
**Description**

I have really enjoyed working with LetMe but I feel that some of what I'd _like_ to do is not possible without either updating the library to handle each case (doesn't make sense to do so) or by allowing library consumers the ability to attach metadata to their actions.

With a `metadata` field, there is no limit to how extensible the library can be!

**Checklist**

- [x] I added tests that cover my proposed changes.
- [x] I updated the documentation related to my changes (if applicable).
