### PR TITLE
Add automatic typespecs for `authorize` functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,43 @@ defmodule MyApp.Blog do
 end
 ```
 
+#### Typespecs
+
+As part of the auto-generated `authorize` set of functions, typespecs are also generated. For
+example, with the policy:
+
+```elixir
+defmodule MyApp.Policy do
+  use LetMe.Policy, error_reason: :not_allowed
+
+  object :article do
+    # Creating articles is allowed if the user role is `editor` or `writer`.
+    action :create do
+      allow role: :editor
+      allow role: :writer
+    end
+
+    action :read do
+      allow true
+      deny :banned
+    end
+  end
+end
+```
+
+The following typespecs are generated in the resultant policy module:
+
+```
+@type :: action() :: :article_create | :article_read
+
+@spec authorize(action(), any(), any(), keyword()) :: :ok | {:error, :not_allowed}
+@spec authorize?(action(), any(), any(), keyword()) :: boolean()
+@spec authorize!(action(), any(), any(), keyword()) :: :ok
+```
+
+This allows you to use dialyzer to statically check your `authorize` calls to ensure valid actions
+are specified, rather than relying on runtime warnings.
+
 ### Introspection
 
 With the introspection functions, you can get the complete list of authorization

--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,7 @@ defmodule LetMe.MixProject do
   defp deps do
     [
       {:credo, "~> 1.7.0", only: [:dev, :test], runtime: false},
-      {:dialyxir, "~> 1.3.0", only: [:dev], runtime: false},
+      {:dialyxir, "~> 1.3.0", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.21", only: :dev, runtime: false},
       {:excoveralls, "~> 0.10", only: :test}
     ]

--- a/test/let_me/policy_test.exs
+++ b/test/let_me/policy_test.exs
@@ -734,4 +734,20 @@ defmodule LetMe.PolicyTest do
       end
     end
   end
+
+  describe "typespec generation" do
+    test "should generate action() typespec" do
+      assert Code.Typespec.fetch_types(LetMe.TypespecTestPolicy) ==
+               {:ok,
+                [
+                  type:
+                    {:action,
+                     {:type, 1, :union,
+                      [
+                        {:atom, 0, :type_check_write},
+                        {:atom, 0, :type_check_read}
+                      ]}, []}
+                ]}
+    end
+  end
 end

--- a/test/support/typespec_test_policy.ex
+++ b/test/support/typespec_test_policy.ex
@@ -1,0 +1,24 @@
+defmodule LetMe.TypespecTestPolicy do
+  @moduledoc """
+  This is a trivial policy for the purposes of testing typespec generation.
+  """
+  use LetMe.Policy
+
+  object :type_check do
+    action :read do
+      allow :own_resource
+    end
+
+    action :write do
+      allow :same_user
+    end
+  end
+
+  # A test call to test the behaviour of the typespecs. When
+  # `MIX_ENV=test mix dialyzer` is run, this should generate a warning for the
+  # `:invalid_action` call, but not the `:type_check_read` one.
+  def test_call do
+    authorize(:type_check_read, nil, nil)
+    authorize(:invalid_action, nil, nil)
+  end
+end


### PR DESCRIPTION
**Description**

This change adds auto-generation of an @action typespec and @specs for the various `authorize` calls in a generated policy module. These typespecs explicitly specify the supported actions, allowing dialyzer to be used for static checking of the validity of action names passed in.

**Checklist**

- [x] I added tests that cover my proposed changes.
- [x] I updated the documentation related to my changes (if applicable).
