### PR TITLE
custom error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Changed
+
+- You can now override the exception message used by
+  `c:LetMe.Policy.authorize!/4` (e.g.
+  `use LetMe.Policy, error_message: "Not today, chap."`).
+
 ## [1.2.1] - 2023-06-28
 
 ### Changed

--- a/lib/let_me/builder.ex
+++ b/lib/let_me/builder.ex
@@ -66,6 +66,7 @@ defmodule LetMe.Builder do
   def authorize_functions(%{} = rules, opts) do
     check_module = Keyword.fetch!(opts, :check_module)
     error_reason = Keyword.fetch!(opts, :error_reason)
+    error_message = Keyword.fetch!(opts, :error_message)
     rule_clauses = Enum.map(rules, &permit_function_clause(&1, check_module))
 
     typespec =
@@ -110,7 +111,7 @@ defmodule LetMe.Builder do
       def authorize!(action, subject, object \\ nil, opts \\ []) do
         if authorize?(action, subject, object, opts),
           do: :ok,
-          else: raise(LetMe.UnauthorizedError)
+          else: raise(LetMe.UnauthorizedError, message: unquote(error_message))
       end
     end
   end

--- a/lib/let_me/policy.ex
+++ b/lib/let_me/policy.ex
@@ -49,6 +49,8 @@ defmodule LetMe.Policy do
     to `__MODULE__.Checks`.
   - `error_reason` - The error reason used by the `c:authorize/4` callback.
     Defaults to `:unauthorized`.
+  - `error_message` - The error message used by the `c:authorize!/4`. Defaults
+    to "unauthorized".
 
   ## Check module
 
@@ -451,7 +453,8 @@ defmodule LetMe.Policy do
     opts =
       Keyword.validate!(opts,
         check_module: Module.concat(__CALLER__.module, Checks),
-        error_reason: :unauthorized
+        error_reason: :unauthorized,
+        error_message: "unauthorized"
       )
 
     quote do

--- a/lib/let_me/unauthorized_error.ex
+++ b/lib/let_me/unauthorized_error.ex
@@ -2,5 +2,9 @@ defmodule LetMe.UnauthorizedError do
   @moduledoc """
   Raised by `c:LetMe.Policy.authorize!/4` if a request is unauthorized.
   """
-  defexception message: "unauthorized"
+  defexception [:message]
+
+  def message(exception) do
+    exception.message || "unauthorized"
+  end
 end

--- a/test/let_me/policy_test.exs
+++ b/test/let_me/policy_test.exs
@@ -715,6 +715,12 @@ defmodule LetMe.PolicyTest do
       assert PolicyShort.authorize(:article_create, %{role: :nobody}) ==
                {:error, :forbidden}
     end
+
+    test "can configure error message" do
+      assert_raise LetMe.UnauthorizedError, "What were you thinking?", fn ->
+        PolicyShort.authorize!(:article_create, %{role: :nobody})
+      end
+    end
   end
 
   describe "authorize!/4" do

--- a/test/support/policy_short.ex
+++ b/test/support/policy_short.ex
@@ -3,7 +3,8 @@ defmodule MyApp.PolicyShort do
 
   use LetMe.Policy,
     check_module: MyApp.Checks,
-    error_reason: :forbidden
+    error_reason: :forbidden,
+    error_message: "What were you thinking?"
 
   object :article do
     action :create do


### PR DESCRIPTION
- feat(policy): add option to override exception message in `__using__` macro
- chore: update changelog
