### PR TITLE
fix docs about passing module

### DIFF
--- a/lib/let_me.ex
+++ b/lib/let_me.ex
@@ -121,6 +121,9 @@ defmodule LetMe do
   object name, and the second element is the actual object, e.g.
   `{:article, %Article{}}`.
 
+  If you registered the schema module with `LetMe.Policy.object/3`, you can
+  pass the struct without tagging it with the object name, e.g. `%Article{}`.
+
   This function is used internally by `c:LetMe.Policy.filter_allowed_actions/3`.
 
   ## Example

--- a/lib/let_me/policy.ex
+++ b/lib/let_me/policy.ex
@@ -238,8 +238,8 @@ defmodule LetMe.Policy do
         }
       ]
 
-  If you registered the schema module with `LetMe.Policy.object/3`, you can also
-  pass the schema module or the struct instead of a tuple.
+  If you registered the schema module with `LetMe.Policy.object/3`, you can
+  pass the struct without tagging it with the object name.
 
       iex> rules = MyApp.Policy.list_rules()
       iex> MyApp.Policy.filter_allowed_actions(

--- a/test/let_me/policy_test.exs
+++ b/test/let_me/policy_test.exs
@@ -289,6 +289,14 @@ defmodule LetMe.PolicyTest do
       assert [%Rule{name: :article_update}, %Rule{name: :article_view}] =
                Policy.filter_allowed_actions(rules, %{id: 1}, object)
     end
+
+    test "can filter by passing the struct only" do
+      rules = Policy.list_rules()
+      object = %Article{user_id: 1}
+
+      assert [%Rule{name: :article_view}] =
+               Policy.filter_allowed_actions(rules, %{id: 2}, object)
+    end
   end
 
   describe "get_rule/1" do


### PR DESCRIPTION
- test: ensure struct can be passed to filter_allowed_actions/3
- doc: remove note about passing schema module to filter function

relates to #58 
