### PR TITLE
Evaluate rule checks lazily

### DIFF
--- a/test/let_me/policy_test.exs
+++ b/test/let_me/policy_test.exs
@@ -69,6 +69,13 @@ defmodule LetMe.PolicyTest do
       action :with_metadata do
         metadata :desc_ja, "指定されたユーザーに対して、指定された機能を無効にします。"
       end
+
+      action :lazy_eval do
+        allow :lookup_false
+        allow :lookup_false
+        allow :lookup_true
+        allow :lookup_false
+      end
     end
 
     object :complex, MyApp.Blog.Article do
@@ -463,6 +470,17 @@ defmodule LetMe.PolicyTest do
                %{user_id: 2}
              ) == false
     end
+
+    test "evaluates rule checks lazily" do
+      :ets.new(:lookups, [:set, :named_table])
+      :ets.insert(:lookups, {:counter, 0})
+
+      # Should only increment counter by 3
+      TestPolicy.authorize?(:simple_lazy_eval, %{})
+
+      assert :ets.lookup(:lookups, :counter) == [counter: 3]
+    end
+
 
     test "returns false and logs warning if rule does not exist" do
       assert capture_log([level: :warning], fn ->

--- a/test/support/checks.ex
+++ b/test/support/checks.ex
@@ -28,6 +28,17 @@ defmodule MyApp.Checks do
 
   def has_valid_reason(_, _), do: false
 
+  # Simulates an extarnal lookup
+  def lookup_true(_, _) do
+    :ets.update_counter(:lookups, :counter, {2, 1})
+    true
+  end
+
+  def lookup_false(_, _) do
+    :ets.update_counter(:lookups, :counter, {2, 1})
+    false
+  end
+
   # pre-hooks
 
   def preload_groups(%{} = subject, %{} = object) do


### PR DESCRIPTION
When having longer authorization rules that perform more complex logic, we don't have to evaluate all of the rule checks if we find one that is matching. In this example, if each `allow` rule performs a database lookup, we previously needed to perform 3 database lookups even if the first `allow role: admin` rule matched. This can obviously be optimized.

```elixir
object :articles do
    action :edit do
      allow role: :admin
      allow :own_resource
      allow :group_resource
   end
end
```

This PR makes makes rule evaluation lazy, ie. it will try each rule in sequence, and if one matches, it will not try to match with any more.

## Checklist

- [x] I added tests that cover my proposed changes.
- [x] I updated the documentation related to my changes (if applicable).